### PR TITLE
man page: update BUGS section

### DIFF
--- a/lsof.8
+++ b/lsof.8
@@ -4374,7 +4374,7 @@ One way to create such file structures is to run X clients with the DISPLAY
 variable set to ``:0.0''.
 .PP
 The
-.BI +|\-f [cfgGn]
+.BI +|\-f [cfn]
 option is not supported under /proc\-based Linux
 .IR lsof ,
 because it doesn't read kernel structures from kernel memory.


### PR DESCRIPTION
g and G flags for [-|+]f options are supported on Linux.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>